### PR TITLE
Improve devcontainer setup with Dockerfile and VSCode customizations

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,10 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
-
+USER root
+RUN npm install -g ctx7 opencode-ai \
+    && chown -R node:node /usr/local/share/npm-global/lib/node_modules
+USER node
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,9 +24,9 @@
 				"terminal.integrated.profiles.linux": {
 					"bash": {
 						"path": "/bin/bash"
-					}
-				}
-			}
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      }
     }
   }
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,12 @@
     "vscode": {
       "extensions": ["GitHub.copilot"],
 			"settings": {
-				"terminal.integrated.shell.linux": "/bin/bash"
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"terminal.integrated.profiles.linux": {
+					"bash": {
+						"path": "/bin/bash"
+					}
+				}
 			}
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,28 +1,29 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres
 {
-	"name": "Node.js & PostgreSQL",
-	"dockerComposeFile": "docker-compose.yml",
-	"service": "app",
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "name": "Node.js & PostgreSQL",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// This can be used to network with other containers or with the host.
-	"forwardPorts": [8088],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // This can be used to network with other containers or with the host.
+  "forwardPorts": [8088],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"extensions": ["GitHub.copilot"]
-		}
-	}
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm install -g opencode-ai ctx7",
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": ["GitHub.copilot"],
+			"settings": {
+				"terminal.integrated.shell.linux": "/bin/bash"
+			}
+    }
+  }
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:OPENCODE_MCP_TOKEN}"
+      },
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
This pull request updates the development container configuration to support the `opencode-ai` and `ctx7` tools, and adds an initial configuration file for OpenCode integration. The changes ensure these tools are globally available in the container and configure the environment for easier use with VS Code.

**Development container enhancements:**

* Modified `.devcontainer/Dockerfile` to globally install `opencode-ai` and `ctx7` via npm, ensuring these tools are available for all users in the container.
* Updated `.devcontainer/devcontainer.json` to run a post-create command that installs `opencode-ai` and `ctx7`, adds the VS Code Copilot extension, and sets the integrated terminal to use Bash for consistency.

**OpenCode integration:**

* Added a new `opencode.json` configuration file to enable and configure remote access to the Context7 MCP service, using an environment variable for authentication.…ved setup

- Added npm global installations for ctx7 and opencode-ai in Dockerfile.
- Changed user context to root for installations and reverted to node afterward.
- Updated devcontainer.json to include a postCreateCommand for npm installations.
- Enhanced VSCode customizations with terminal settings.

These changes streamline the development environment setup by ensuring necessary packages are installed automatically, improving developer experience and efficiency when working with the project.