### PR TITLE
Add unit tests for Locations module functionality

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,4 +32,10 @@ export default tseslint.config(
       "prettier/prettier": ["error", { endOfLine: "auto" }],
     },
   },
+  {
+    files: ['**/*.spec.ts', '**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/unbound-method': 'off',
+    },
+  },
 );

--- a/src/modules/locations/locations.controller.spec.ts
+++ b/src/modules/locations/locations.controller.spec.ts
@@ -49,7 +49,7 @@ describe('LocationsController', () => {
     it('should call LocationsService.retrieve and return an array of locations', async () => {
       const result = await controller.getLocations();
 
-      expect(jest.spyOn(service, 'retrieve')).toHaveBeenCalledTimes(1);
+      expect(service.retrieve).toHaveBeenCalledTimes(1);
       expect(result).toEqual([mockLocationRecord]);
     });
   });
@@ -66,8 +66,8 @@ describe('LocationsController', () => {
 
       const result = await controller.createLocation(createDto);
 
-      expect(jest.spyOn(service, 'create')).toHaveBeenCalledWith(createDto);
-      expect(jest.spyOn(service, 'create')).toHaveBeenCalledTimes(1);
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(service.create).toHaveBeenCalledTimes(1);
       expect(result).toEqual(mockLocationRecord);
     });
   });
@@ -81,8 +81,8 @@ describe('LocationsController', () => {
 
       const result = await controller.updateLocation(updateDto);
 
-      expect(jest.spyOn(service, 'update')).toHaveBeenCalledWith(updateDto);
-      expect(jest.spyOn(service, 'update')).toHaveBeenCalledTimes(1);
+      expect(service.update).toHaveBeenCalledWith(updateDto);
+      expect(service.update).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         ...mockLocationRecord,
         name: 'Updated Location',

--- a/src/modules/locations/locations.controller.spec.ts
+++ b/src/modules/locations/locations.controller.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LocationsController } from './locations.controller';
+import { LocationsService } from './locations.service';
+import { LocationsCreateDto } from './dtos/locations-create.dto';
+import { LocationsUpdateDto } from './dtos/locations-update.dto';
+import { LocationRecord } from './locations.interface';
+
+const mockLocationRecord: LocationRecord = {
+  id: 1,
+  name: 'Test Location',
+  type: 'Shelter',
+  address: '123 Main St',
+  contact: '555-1234',
+  coords: { lat: 40.7128, lng: -74.006 },
+};
+
+describe('LocationsController', () => {
+  let controller: LocationsController;
+  let service: LocationsService;
+
+  beforeEach(async () => {
+    const mockLocationsService = {
+      retrieve: jest.fn().mockResolvedValue([mockLocationRecord]),
+      create: jest.fn().mockResolvedValue(mockLocationRecord),
+      update: jest
+        .fn()
+        .mockResolvedValue({ ...mockLocationRecord, name: 'Updated Location' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LocationsController],
+      providers: [
+        {
+          provide: LocationsService,
+          useValue: mockLocationsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<LocationsController>(LocationsController);
+    service = module.get<LocationsService>(LocationsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getLocations', () => {
+    it('should call LocationsService.retrieve and return an array of locations', async () => {
+      const result = await controller.getLocations();
+
+      expect(jest.spyOn(service, 'retrieve')).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([mockLocationRecord]);
+    });
+  });
+
+  describe('createLocation', () => {
+    it('should call LocationsService.create with dto and return the created location', async () => {
+      const createDto: LocationsCreateDto = {
+        name: 'Test Location',
+        type: 'Shelter',
+        address: '123 Main St',
+        contact: '555-1234',
+        coords: { lat: 40.7128, lng: -74.006 },
+      };
+
+      const result = await controller.createLocation(createDto);
+
+      expect(jest.spyOn(service, 'create')).toHaveBeenCalledWith(createDto);
+      expect(jest.spyOn(service, 'create')).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockLocationRecord);
+    });
+  });
+
+  describe('updateLocation', () => {
+    it('should call LocationsService.update with dto and return the updated location', async () => {
+      const updateDto: LocationsUpdateDto = {
+        id: 1,
+        name: 'Updated Location',
+      };
+
+      const result = await controller.updateLocation(updateDto);
+
+      expect(jest.spyOn(service, 'update')).toHaveBeenCalledWith(updateDto);
+      expect(jest.spyOn(service, 'update')).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        ...mockLocationRecord,
+        name: 'Updated Location',
+      });
+    });
+  });
+});

--- a/src/modules/locations/locations.repository.spec.ts
+++ b/src/modules/locations/locations.repository.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LocationsRepository } from './locations.repository';
+import { PrismaService } from '../../infrastructure/prisma.service';
+import {
+  Location,
+  LocationRecord,
+  LocationUpdate,
+} from './locations.interface';
+
+const mockLocationRecord: LocationRecord = {
+  id: 1,
+  name: 'Test Repo Location',
+  type: 'Clinic',
+  address: '789 Health Way',
+  contact: '555-9012',
+  coords: { lat: 51.5074, lng: -0.1278 },
+};
+
+describe('LocationsRepository', () => {
+  let repository: LocationsRepository;
+
+  let mockLocationsDelegate: {
+    findMany: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockLocationsDelegate = {
+      findMany: jest.fn().mockResolvedValue([mockLocationRecord]),
+      create: jest.fn().mockResolvedValue(mockLocationRecord),
+      update: jest.fn().mockResolvedValue({
+        ...mockLocationRecord,
+        name: 'Repo Updated Location',
+      }),
+    };
+
+    // We mock the deep property prisma.client.locations
+    const mockPrismaService = {
+      client: {
+        locations: mockLocationsDelegate,
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocationsRepository,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<LocationsRepository>(LocationsRepository);
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should call prisma.client.locations.findMany and return an array of locations', async () => {
+      const result = await repository.findAll();
+
+      // Ensure the deeply nested mocked method is called
+      expect(mockLocationsDelegate.findMany).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([mockLocationRecord]);
+    });
+  });
+
+  describe('create', () => {
+    it('should call prisma.client.locations.create with wrapped data and return record', async () => {
+      const newLocation: Location = {
+        name: 'Test Repo Location',
+        type: 'Clinic',
+        address: '789 Health Way',
+        contact: '555-9012',
+        coords: { lat: 51.5074, lng: -0.1278 },
+      };
+
+      const result = await repository.create(newLocation);
+
+      expect(mockLocationsDelegate.create).toHaveBeenCalledWith({
+        data: newLocation,
+      });
+      expect(mockLocationsDelegate.create).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockLocationRecord);
+    });
+  });
+
+  describe('update', () => {
+    it('should split id from data and call prisma.client.locations.update', async () => {
+      const updateData: LocationUpdate = {
+        id: 1,
+        name: 'Repo Updated Location',
+      };
+
+      const result = await repository.update(updateData);
+
+      expect(mockLocationsDelegate.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { name: 'Repo Updated Location' },
+      });
+      expect(mockLocationsDelegate.update).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        ...mockLocationRecord,
+        name: 'Repo Updated Location',
+      });
+    });
+  });
+});

--- a/src/modules/locations/locations.service.spec.ts
+++ b/src/modules/locations/locations.service.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LocationsService } from './locations.service';
+import { LocationsRepository } from './locations.repository';
+import {
+  Location,
+  LocationRecord,
+  LocationUpdate,
+} from './locations.interface';
+
+const mockLocationRecord: LocationRecord = {
+  id: 1,
+  name: 'Test Service Location',
+  type: 'Food Bank',
+  address: '456 Service Blvd',
+  contact: '555-5678',
+  coords: { lat: 34.0522, lng: -118.2437 },
+};
+
+describe('LocationsService', () => {
+  let service: LocationsService;
+  let repository: LocationsRepository;
+
+  beforeEach(async () => {
+    const mockLocationsRepository = {
+      findAll: jest.fn().mockResolvedValue([mockLocationRecord]),
+      create: jest.fn().mockResolvedValue(mockLocationRecord),
+      update: jest.fn().mockResolvedValue({
+        ...mockLocationRecord,
+        name: 'Service Updated Location',
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocationsService,
+        {
+          provide: LocationsRepository,
+          useValue: mockLocationsRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<LocationsService>(LocationsService);
+    repository = module.get<LocationsRepository>(LocationsRepository);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('retrieve', () => {
+    it('should call LocationsRepository.findAll and return array of records', async () => {
+      const result = await service.retrieve();
+
+      expect(jest.spyOn(repository, 'findAll')).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([mockLocationRecord]);
+    });
+  });
+
+  describe('create', () => {
+    it('should call LocationsRepository.create with location and return record', async () => {
+      const newLocation: Location = {
+        name: 'Test Service Location',
+        type: 'Food Bank',
+        address: '456 Service Blvd',
+        contact: '555-5678',
+        coords: { lat: 34.0522, lng: -118.2437 },
+      };
+
+      const result = await service.create(newLocation);
+
+      expect(jest.spyOn(repository, 'create')).toHaveBeenCalledWith(
+        newLocation,
+      );
+      expect(jest.spyOn(repository, 'create')).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockLocationRecord);
+    });
+  });
+
+  describe('update', () => {
+    it('should call LocationsRepository.update with updated payload and return record', async () => {
+      const updateData: LocationUpdate = {
+        id: 1,
+        name: 'Service Updated Location',
+      };
+
+      const result = await service.update(updateData);
+
+      expect(jest.spyOn(repository, 'update')).toHaveBeenCalledWith(updateData);
+      expect(jest.spyOn(repository, 'update')).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        ...mockLocationRecord,
+        name: 'Service Updated Location',
+      });
+    });
+  });
+});

--- a/src/modules/locations/locations.service.spec.ts
+++ b/src/modules/locations/locations.service.spec.ts
@@ -52,7 +52,7 @@ describe('LocationsService', () => {
     it('should call LocationsRepository.findAll and return array of records', async () => {
       const result = await service.retrieve();
 
-      expect(jest.spyOn(repository, 'findAll')).toHaveBeenCalledTimes(1);
+      expect(repository.findAll).toHaveBeenCalledTimes(1);
       expect(result).toEqual([mockLocationRecord]);
     });
   });
@@ -69,10 +69,8 @@ describe('LocationsService', () => {
 
       const result = await service.create(newLocation);
 
-      expect(jest.spyOn(repository, 'create')).toHaveBeenCalledWith(
-        newLocation,
-      );
-      expect(jest.spyOn(repository, 'create')).toHaveBeenCalledTimes(1);
+      expect(repository.create).toHaveBeenCalledWith(newLocation);
+      expect(repository.create).toHaveBeenCalledTimes(1);
       expect(result).toEqual(mockLocationRecord);
     });
   });
@@ -86,8 +84,8 @@ describe('LocationsService', () => {
 
       const result = await service.update(updateData);
 
-      expect(jest.spyOn(repository, 'update')).toHaveBeenCalledWith(updateData);
-      expect(jest.spyOn(repository, 'update')).toHaveBeenCalledTimes(1);
+      expect(repository.update).toHaveBeenCalledWith(updateData);
+      expect(repository.update).toHaveBeenCalledTimes(1);
       expect(result).toEqual({
         ...mockLocationRecord,
         name: 'Service Updated Location',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "types": ["jest", "node"]
   },
   "exclude": ["expressjs", "node_modules", "dist"]
 }


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the Locations module, covering the controller, service, and repository layers. These tests use Jest to mock dependencies and validate the correct behavior of each layer's methods, ensuring that the module's core CRUD operations are thoroughly tested in isolation.

**Testing coverage improvements:**

* Added unit tests for `LocationsController` to verify that controller methods correctly interact with the `LocationsService` and return expected results for retrieving, creating, and updating locations.
* Added unit tests for `LocationsService` to ensure service methods properly delegate to the `LocationsRepository` and handle data as expected for retrieve, create, and update operations.
* Added unit tests for `LocationsRepository` to confirm repository methods correctly interact with the mocked Prisma client for database operations, including proper handling of input data and results for findAll, create, and update.- Created new test files for LocationsController, LocationsRepository, and LocationsService.
- Implemented mock data and service methods to test the functionality of the Locations module.
- Added tests for retrieving, creating, and updating locations in the LocationsService.
- Ensured that the LocationsController correctly interacts with the LocationsService.

These changes enhance the test coverage for the Locations module, ensuring that the core functionalities are validated through unit tests. This will improve the reliability of the code and facilitate easier maintenance and future development.